### PR TITLE
Modify notification feature

### DIFF
--- a/CoreToDo for Qiita/CoreToDo for Qiita/AppDelegate.swift
+++ b/CoreToDo for Qiita/CoreToDo for Qiita/AppDelegate.swift
@@ -8,16 +8,17 @@
 
 import UIKit
 import CoreData
+import UserNotifications
 
 @UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {
 
     var window: UIWindow?
 
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
-        
+
+        UNUserNotificationCenter.current().delegate = self
+
         return true
     }
 


### PR DESCRIPTION
# Description

## 解決したいこと

- 通知をタップしてアプリを開くと`task.notifiedAt`を`nil`にする。
- アプリがforegroundの状態でも通知が来るようにする。
  - その場合なら通知をタップしなくても`task.notifiedAt`を`nil`にする。
